### PR TITLE
add 'always on top' key/mouse bindings

### DIFF
--- a/config/bodhi/e.src
+++ b/config/bodhi/e.src
@@ -5767,6 +5767,13 @@ group "E_Config" struct {
         group "E_Config_Binding_Key" struct {
             value "context" int: 9;
             value "modifiers" int: 6;
+            value "key" string: "t";
+            value "action" string: "window_stack_top_toggle";
+            value "any_mod" uchar: 0;
+        }
+        group "E_Config_Binding_Key" struct {
+            value "context" int: 9;
+            value "modifiers" int: 6;
             value "key" string: "w";
             value "action" string: "window_menu";
             value "any_mod" uchar: 0;

--- a/src/bin/e_actions.c
+++ b/src/bin/e_actions.c
@@ -427,6 +427,65 @@ ACT_FN_GO(window_sticky, )
 }
 
 /***************************************************************************/
+ACT_FN_GO(window_stack_top_toggle, __UNUSED__)
+{
+   if (!obj) obj = E_OBJECT(e_border_focused_get());
+   if (!obj) return;
+   if (obj->type != E_BORDER_TYPE)
+     {
+        obj = E_OBJECT(e_border_focused_get());
+        if (!obj) return;
+     }
+
+   if (!((E_Border *)obj)->lock_user_stacking)
+     {
+        E_Border *bd;
+        bd = (E_Border *)obj;
+        if (bd->layer != E_LAYER_ABOVE)
+          e_border_layer_set(bd, E_LAYER_ABOVE);
+        else e_border_layer_set(bd, E_LAYER_NORMAL);
+     }
+}
+
+/***************************************************************************/
+ACT_FN_GO(window_stack_top, __UNUSED__)
+{
+   if (!obj) obj = E_OBJECT(e_border_focused_get());
+   if (!obj) return;
+   if (obj->type != E_BORDER_TYPE)
+     {
+        obj = E_OBJECT(e_border_focused_get());
+        if (!obj) return;
+     }
+
+   if (!((E_Border *)obj)->lock_user_stacking)
+     {
+        E_Border *bd;
+        bd = (E_Border *)obj;
+        e_border_layer_set(bd, E_LAYER_ABOVE);
+     }
+}
+
+/***************************************************************************/
+ACT_FN_GO(window_stack_normal, __UNUSED__)
+{
+   if (!obj) obj = E_OBJECT(e_border_focused_get());
+   if (!obj) return;
+   if (obj->type != E_BORDER_TYPE)
+     {
+        obj = E_OBJECT(e_border_focused_get());
+        if (!obj) return;
+     }
+
+   if (!((E_Border *)obj)->lock_user_stacking)
+     {
+        E_Border *bd;
+        bd = (E_Border *)obj;
+        e_border_layer_set(bd, E_LAYER_NORMAL);
+     }
+}
+
+/***************************************************************************/
 ACT_FN_GO(window_iconic_toggle, __UNUSED__)
 {
    E_Border *bd;
@@ -3035,6 +3094,19 @@ e_actions_init(void)
    ACT_GO(window_sticky);
    e_action_predef_name_set(N_("Window : State"), N_("Sticky Mode Enable"),
                             "window_sticky", NULL, NULL, 0);
+
+   /* window_stack_top_toggle */
+   ACT_GO(window_stack_top_toggle);
+   e_action_predef_name_set(N_("Window : State"), N_("Always On Top Toggle"),
+                            "window_stack_top_toggle", NULL, NULL, 0);
+
+   ACT_GO(window_stack_top);
+   e_action_predef_name_set(N_("Window : State"), N_("Always On Top Enable"),
+                            "window_stack_top", NULL, NULL, 0);
+
+   ACT_GO(window_stack_normal);
+   e_action_predef_name_set(N_("Window : State"), N_("Always On Top Disable"),
+                            "window_stack_normal", NULL, NULL, 0);
 
    /* window_iconic_toggle */
    ACT_GO(window_iconic_toggle);

--- a/src/modules/conf_keybindings/e_int_config_keybindings.c
+++ b/src/modules/conf_keybindings/e_int_config_keybindings.c
@@ -522,6 +522,9 @@ _restore_key_binding_defaults_cb(void *data,
    CFG_KEYBIND_DFLT(E_BINDING_CONTEXT_ANY, "s",
                     E_BINDING_MODIFIER_CTRL | E_BINDING_MODIFIER_ALT, 0,
                     "window_sticky_toggle", NULL);
+   CFG_KEYBIND_DFLT(E_BINDING_CONTEXT_ANY, "t",
+                    E_BINDING_MODIFIER_CTRL | E_BINDING_MODIFIER_ALT, 0,
+                    "window_stack_top_toggle", NULL);
    CFG_KEYBIND_DFLT(E_BINDING_CONTEXT_ANY, "f",
                     E_BINDING_MODIFIER_CTRL | E_BINDING_MODIFIER_ALT, 0,
                     "window_fullscreen_toggle", NULL);


### PR DESCRIPTION
Create 3 new options in the key & mouse bindings -- Always On Top Toggle, Always On Top Enable, Always On Top Disable. Added < ctrl + alt + T > as default keybinding for 'Always On Top Toggle'.