### PR TITLE
 Color dialog value correction fix 

### DIFF
--- a/src/bin/e_widget_csel.c
+++ b/src/bin/e_widget_csel.c
@@ -146,9 +146,9 @@ _e_wid_cb_color_changed(void *data, Evas_Object *o)
      {
         char buf[10];
 
-        if (o == eo) continue;
+        //if (o == eo) continue;
         switch (i)
-          {
+        {
            case E_COLOR_COMPONENT_R:
              snprintf(buf, 10, "%i", wd->cv->r);
              break;
@@ -169,7 +169,7 @@ _e_wid_cb_color_changed(void *data, Evas_Object *o)
              break;
            default:
              break;
-          }
+        }
         e_widget_entry_text_set(eo, buf);
         i++;
      }


### PR DESCRIPTION
Hello Jeff,

Stefan (The waiter) and I have fixed the color dialog issue.
See the thread on the forum: http://forums.bodhilinux.com/index.php?/topic/14362-color-dialog-bug/

Let me know if the fix is ok like this. 
I've tested the fix with Bodhi 4.4 with latest updates.

Kind regards,

Marcel